### PR TITLE
[MRG] fix some stuff in runme.py to do with query and ksize

### DIFF
--- a/runme.py
+++ b/runme.py
@@ -13,6 +13,9 @@ def main():
     p.add_argument('query')
     args = p.parse_args()
 
+    # fix path for query file in case it's relative
+    args.query = os.path.abspath(args.query)
+
     print('removing outputs/')
     try:
         shutil.rmtree('./outputs/')

--- a/sourmash/Snakefile
+++ b/sourmash/Snakefile
@@ -2,7 +2,7 @@ import sys, os
 
 # load stuff from config file
 SAMPLES=config.get('metagenome_files', [])
-QUERY=config.get('query', '')
+QUERY=config.get('query_file', '')
 ksize = config.get('ksize', 'unset')
 
 # don't change these :)
@@ -59,7 +59,7 @@ rule prepare_sample:
     shell: """
        rm -fr {output}
        mkdir -p {output}
-       sourmash sketch dna -p k=31 {SAMPLES} -o {output}/sample.sig
+       sourmash sketch dna -p k={ksize} {SAMPLES} -o {output}/sample.sig
     """
 
 rule prepare_query:
@@ -67,7 +67,7 @@ rule prepare_query:
     shell: """
        rm -fr {output}
        mkdir -p {output}
-       sourmash sketch dna -p k=31 {QUERY} -o {output}/query.sig
+       sourmash sketch dna -p k={ksize} {QUERY} -o {output}/query.sig
     """
 
 rule do_query:

--- a/sourmash/conf-basic.yml
+++ b/sourmash/conf-basic.yml
@@ -1,7 +1,6 @@
+# one or more files that will be combined into a single sample databsae
 metagenome_files:
 - ../data/genome-s10+s11.fa.gz
 
-query: ../data/genome-s10.fa.gz
-
-# sourmash config params
+# sourmash-specific config params
 ksize: 31


### PR DESCRIPTION
...mistakes were made 😆 

This PR fixes some mistakes I made that prevented `runme.py` from doing the Right Thing when it came to query files and ksize. Specifically,

- [x] the `query` argument to runme.py now properly overrides the `query_file` parameter in the config
- [x] the config file no longer contains the default query file
- [x] the query file passed into runme.py properly deals with relative paths
- [x] the `ksize` parameter is properly interpreted

Ready for review & merge @ropolomx @bluegenes 