### PR TITLE
[WIP] Mash

### DIFF
--- a/mash/Snakefile
+++ b/mash/Snakefile
@@ -76,7 +76,7 @@ rule prepare_query:
 rule do_query:
     input:
         query = f"{QUERY_PREP}/query.sig",
-        sample = f"{SAMPLES}/sample.sig",
+        sample = f"{SAMPLES}",
     output: directory("results")
     conda: "../conf/env/mash2.yml"
     shell: """

--- a/mash/Snakefile
+++ b/mash/Snakefile
@@ -1,0 +1,93 @@
+import sys, os
+
+# load stuff from config file
+SAMPLES=config.get('metagenome_files', [])
+QUERY=config.get('query_file', '')
+ksize = config.get('ksize', 'unset')
+
+# don't change these :)
+OUTPUT_DIR=config['output_dir']
+SAMPLE_PREP=os.path.join(OUTPUT_DIR, 'prep.sample')
+QUERY_PREP=os.path.join(OUTPUT_DIR, 'prep.query')
+
+###
+### check configuration
+###
+
+print("Checking configuration...", file=sys.stderr)
+
+do_fail = False
+
+SAMPLES = [ x.strip() for x in SAMPLES ]
+SAMPLES = [ x for x in SAMPLES if x ]
+
+if not SAMPLES:
+    print("No files in 'metagenome_files' in the config?", file=sys.stderr)
+    do_fail = True
+
+if not QUERY:
+    print("No 'query' in the config?", file=sys.stderr)
+    do_fail = True
+
+try:
+    ksize = int(ksize)
+except ValueError:
+    print(f"Invalid ksize {repr(ksize)}", file=sys.stderr)
+    do_fail = True
+
+for sample in SAMPLES:
+    if not os.path.exists(sample):
+        print(f"metagenome file '{sample}' does not exist.", file=sys.stderr)
+        do_fail = True
+
+if not os.path.exists(QUERY):
+    print(f"query file '{QUERY}' does not exist.", file=sys.stderr)
+    do_fail = True
+
+if do_fail:
+    print('Snakefile config checks FAILED.', file=sys.stderr)
+    sys.exit(-1)
+
+print("Configuration PASSED!", file=sys.stderr)
+
+###
+### actual rules to run something
+###
+
+rule prepare_sample:
+    output: directory(SAMPLE_PREP)
+    conda: "../conf/env/mash2.yml"
+    shell: """
+       rm -fr {output}
+       mkdir -p {output}
+       # seems like we leave the sample/target in fasta/fastq etc. format
+       # mash sketch dna -p k={ksize} {SAMPLES} -o {output}/sample.sig
+    """
+
+rule prepare_query:
+    output: directory(QUERY_PREP)
+    conda: "../conf/env/mash2.yml"
+    shell: """
+       rm -fr {output}
+       mkdir -p {output}
+       mash sketch -k {ksize} {QUERY} -o {output}/query.sig
+    """
+
+rule do_query:
+    input:
+        query = f"{QUERY_PREP}/query.sig",
+        sample = f"{SAMPLE_PREP}/sample.sig",
+    output: directory("results")
+    conda: "../conf/env/mash2.yml"
+    shell: """
+       rm -fr {output}
+       mkdir -p {output}
+       # mash screen {input.query} {input.sample} -o {output}/results.csv
+       mash screen {input.query} {input.sample}
+    """
+
+rule install_software:
+    conda: "../conf/env/mash2.yml"
+    shell: """
+       mash --version
+    """

--- a/mash/Snakefile
+++ b/mash/Snakefile
@@ -61,7 +61,8 @@ rule prepare_sample:
        rm -fr {output}
        mkdir -p {output}
        # seems like we leave the sample/target in fasta/fastq etc. format
-       # mash sketch dna -p k={ksize} {SAMPLES} -o {output}/sample.sig
+       # instead of sketching it, we'll just copy it with a new name
+       cp {SAMPLES} {output}/sample.sig
     """
 
 rule prepare_query:
@@ -70,20 +71,26 @@ rule prepare_query:
     shell: """
        rm -fr {output}
        mkdir -p {output}
+       # seems like mash sketch FORCES a .msh extension on the end of your output string...
+       # not cool
        mash sketch -k {ksize} {QUERY} -o {output}/query.sig
     """
 
 rule do_query:
     input:
-        query = f"{QUERY_PREP}/query.sig",
-        sample = f"{SAMPLES}",
+        # this is annoying: mash seems to REQUIRE that the query have a .msh extension...
+        # not cool. initially I was renaming the forced query.sig.msh file to query.sig,
+        # but it just doesn't seem to like it.
+        query = f"{QUERY_PREP}/query.sig.msh",
+        sample = f"{SAMPLE_PREP}/sample.sig",
     output: directory("results")
     conda: "../conf/env/mash2.yml"
     shell: """
        rm -fr {output}
        mkdir -p {output}
-       # mash screen {input.query} {input.sample} -o {output}/results.csv
        mash screen {input.query} {input.sample}
+       # if we want to actually put the results in a file we can do something like this
+       # mash screen {input.query} {input.sample} > {output}/results.csv
     """
 
 rule install_software:

--- a/mash/Snakefile
+++ b/mash/Snakefile
@@ -76,7 +76,7 @@ rule prepare_query:
 rule do_query:
     input:
         query = f"{QUERY_PREP}/query.sig",
-        sample = f"{SAMPLE_PREP}/sample.sig",
+        sample = f"{SAMPLES}/sample.sig",
     output: directory("results")
     conda: "../conf/env/mash2.yml"
     shell: """

--- a/mash/conf-basic.yml
+++ b/mash/conf-basic.yml
@@ -1,0 +1,9 @@
+# one or more files that will be combined into a single sample database
+metagenome_files:
+- ../data/genome-s10+s11.fa.gz
+
+# default output directory
+output_dir: outputs/
+
+# sourmash-specific config params
+ksize: 31


### PR DESCRIPTION
- [x] add './mash/Snakefile
- [x] add './mash/conf-basic.yml
- [ ] fix outputs problem

This is pretty close to done, but it seems like there's some conflict in the outputs directory with the original sourmash workflow.

## sample output

command:
```
./run-one-query mash/conf-basic.yml mash data/genome-s10.fa.gz
```

result:
```
rule do_query:
    input: /home/ubuntu/bothie/outputs/prep.query/query.sig.msh, /home/ubuntu/bothie/outputs/prep.sample/sample.sig
    output: results
    jobid: 0
    resources: tmpdir=/tmp

Activating conda environment: /home/ubuntu/bothie/mash/.snakemake/conda/9bc49899323ab55cc665c3091fc67b68
Loading /home/ubuntu/bothie/outputs/prep.query/query.sig.msh...
   1000 distinct hashes.
Streaming from /home/ubuntu/bothie/outputs/prep.sample/sample.sig...
   Estimated distinct k-mers in mixture: 963520
Summing shared...
Computing coverage medians...
Writing output...
1	1000/1000	1	0	/home/ubuntu/bothie/data/genome-s10.fa.gz	s10
[Tue Sep 28 18:58:46 2021]
Finished job 0.
1 of 1 steps (100%) done
Complete log: /home/ubuntu/bothie/mash/.snakemake/log/2021-09-28T185845.343034.snakemake.log
2021-09-28 18:58:46.780893 END DO QUERY
```