### PR TITLE
[MRG] add logs, benchmarking to snakemake rules

### DIFF
--- a/cmash/Snakefile
+++ b/cmash/Snakefile
@@ -55,6 +55,8 @@ print("Configuration PASSED!", file=sys.stderr)
 rule prepare_sample:
     output: directory(SAMPLE_PREP)
     conda: "../conf/env/cmash.yml"
+    log: f"{OUTPUT_DIR}/logs/cmash/prepare_sample.log"
+    benchmark: f"{OUTPUT_DIR}/logs/cmash/prepare_sample.benchmark"
     shell: """
         rm -rf {output}
         mkdir -p {output}
@@ -67,6 +69,8 @@ rule prepare_sample:
 rule prepare_query:
     output: directory(QUERY_PREP)
     conda: "../conf/env/cmash.yml"
+    log: f"{OUTPUT_DIR}/logs/cmash/prepare_query.log"
+    benchmark: f"{OUTPUT_DIR}/logs/cmash/prepare_query.benchmark"
     shell: """
        rm -rf {output}
        mkdir -p {output}
@@ -78,6 +82,8 @@ rule execute_query:
         query = f"{QUERY_PREP}/query",
         sample = f"{SAMPLE_PREP}/sample.h5",
     output: directory(RESULTS_DIR)
+    log: f"{OUTPUT_DIR}/logs/cmash/execute_query.log"
+    benchmark: f"{OUTPUT_DIR}/logs/cmash/execute_query.benchmark"
     conda: "../conf/env/cmash.yml"
     shell: """
        rm -rf {output}
@@ -104,6 +110,8 @@ rule do_query:
 
 rule install_software:
     conda: "../conf/env/cmash.yml"
+    log: f"{OUTPUT_DIR}/logs/cmash/install_software.log"
+    benchmark: f"{OUTPUT_DIR}/logs/cmash/install_software.benchmark"
     shell: """
 	MakeNodeGraph.py -h
     """

--- a/sourmash/Snakefile
+++ b/sourmash/Snakefile
@@ -64,10 +64,12 @@ print('output directory:', OUTPUT_DIR, file=sys.stderr)
 rule prepare_sample:
     output: directory(SAMPLE_PREP)
     conda: "../conf/env/sourmash4.yml"
+    log: f"{OUTPUT_DIR}/logs/sourmash/prepare_sample.log"
+    benchmark: f"{OUTPUT_DIR}/logs/sourmash/prepare_sample.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
-       sourmash sketch dna -p k={ksize} {SAMPLES} -o {output}/sample.sig
+       sourmash sketch dna -p k={ksize} {SAMPLES} -o {output}/sample.sig 2> {log}
     """
 
 rule prepare_query:
@@ -75,11 +77,13 @@ rule prepare_query:
     conda: "../conf/env/sourmash4.yml"
     params:
         name = os.path.basename(QUERY)
+    log: f"{OUTPUT_DIR}/logs/sourmash/prepare_query.log"
+    benchmark: f"{OUTPUT_DIR}/logs/sourmash/prepare_query.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
        sourmash sketch dna -p k={ksize} {QUERY} -o {output}/query.sig \
-          --merge {params.name}
+          --merge {params.name}  2> {log}
     """
 
 rule execute_query_command:
@@ -88,15 +92,18 @@ rule execute_query_command:
         sample = f"{SAMPLE_PREP}/sample.sig",
     output: directory(RESULTS_DIR)
     conda: "../conf/env/sourmash4.yml"
+    log: f"{OUTPUT_DIR}/logs/sourmash/execute_query.log"
+    benchmark: f"{OUTPUT_DIR}/logs/sourmash/execute_query.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
-       sourmash search --containment {input.query} {input.sample} -o {output}/results.csv
+       sourmash search --containment {input.query} {input.sample} -o {output}/results.csv  2> {log}
     """
 
 rule do_query:
     message: "Run query and evaluate if it found it, or not."
     input: dir=RESULTS_DIR
+    benchmark: f"{OUTPUT_DIR}/logs/sourmash/do_query.benchmark"
     run:
         with open(input.dir + '/results.csv', "rt") as fp:
             lines = fp.readlines()
@@ -113,6 +120,8 @@ rule do_query:
 
 rule install_software:
     conda: "../conf/env/sourmash4.yml"
+    log: f"{OUTPUT_DIR}/logs/sourmash/install_software.log"
+    benchmark: f"{OUTPUT_DIR}/logs/sourmash/install_software.benchmark"
     shell: """
-       sourmash --version
+       sourmash --version 2> {log}
     """


### PR DESCRIPTION
Snakemake can print `psutil` info for each rule

- [x] sourmash
- [x] CMash

example benchmark file:

`cat bothie/outputs/logs/sourmash/execute_query.benchmark`

```
s	h:m:s	max_rss	max_vms	max_uss	max_pss	io_in	io_out	mean_load	cpu_time
0.8784	0:00:00	28.55	88.38	21.54	22.19	0.00	0.00	0.00	0.29
```