### PR TITLE
[MRG] refactor tool execution to be much more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .snakemake
 *~
+outputs.*

--- a/cmash/Snakefile
+++ b/cmash/Snakefile
@@ -14,8 +14,8 @@ include: '../common.snakefile'
 rule prepare_sample:
     output: directory(SAMPLE_PREP)
     conda: "../conf/env/cmash.yml"
-    log: f"{OUTPUT_DIR}/logs/cmash/prepare_sample.log"
-    benchmark: f"{OUTPUT_DIR}/logs/cmash/prepare_sample.benchmark"
+    log: f"{LOG_DIR}/prepare_sample.log"
+    benchmark: f"{LOG_DIR}/prepare_sample.benchmark"
     shell: """
         rm -rf {output}
         mkdir -p {output}
@@ -28,8 +28,8 @@ rule prepare_sample:
 rule prepare_query:
     output: directory(QUERY_PREP)
     conda: "../conf/env/cmash.yml"
-    log: f"{OUTPUT_DIR}/logs/cmash/prepare_query.log"
-    benchmark: f"{OUTPUT_DIR}/logs/cmash/prepare_query.benchmark"
+    log: f"{LOG_DIR}/prepare_query.log"
+    benchmark: f"{LOG_DIR}/prepare_query.benchmark"
     shell: """
        rm -rf {output}
        mkdir -p {output}
@@ -41,8 +41,8 @@ rule execute_query:
         query = f"{QUERY_PREP}/query",
         sample = f"{SAMPLE_PREP}/sample.h5",
     output: directory(RESULTS_DIR)
-    log: f"{OUTPUT_DIR}/logs/cmash/execute_query.log"
-    benchmark: f"{OUTPUT_DIR}/logs/cmash/execute_query.benchmark"
+    log: f"{LOG_DIR}/execute_query.log"
+    benchmark: f"{LOG_DIR}/execute_query.benchmark"
     conda: "../conf/env/cmash.yml"
     shell: """
        rm -rf {output}
@@ -69,8 +69,8 @@ rule do_query:
 
 rule install_software:
     conda: "../conf/env/cmash.yml"
-    log: f"{OUTPUT_DIR}/logs/cmash/install_software.log"
-    benchmark: f"{OUTPUT_DIR}/logs/cmash/install_software.benchmark"
+    log: f"{LOG_DIR}/install_software.log"
+    benchmark: f"{LOG_DIR}/install_software.benchmark"
     shell: """
 	MakeNodeGraph.py -h
     """

--- a/common.snakefile
+++ b/common.snakefile
@@ -1,7 +1,7 @@
 # don't change these :)
 SAMPLE_PREP = config['sample_prep_dir']
-QUERY_PREP = config['query_prep_dir']
-RESULTS_DIR = config['results_dir']
+QUERY_PREP = config.get('query_prep_dir', '')
+RESULTS_DIR = config.get('results_dir', '')
 LOG_DIR = config['log_dir']
 
 ###

--- a/common.snakefile
+++ b/common.snakefile
@@ -1,8 +1,8 @@
 # don't change these :)
-OUTPUT_DIR=config.get('output_dir', 'outputs')
-SAMPLE_PREP=os.path.join(OUTPUT_DIR, 'prep.sample')
-QUERY_PREP=os.path.join(OUTPUT_DIR, 'prep.query')
-RESULTS_DIR=os.path.join(OUTPUT_DIR, 'results')
+SAMPLE_PREP = config['sample_prep_dir']
+QUERY_PREP = config['query_prep_dir']
+RESULTS_DIR = config['results_dir']
+LOG_DIR = config['log_dir']
 
 ###
 ### check configuration
@@ -33,14 +33,9 @@ for sample in SAMPLES:
 #    print(f"query file '{QUERY}' does not exist.", file=sys.stderr)
 #    do_fail = True
 
-if not OUTPUT_DIR.startswith('/'):
-    print(f"output directory '{OUTPUT_DIR}' is not an absolute path.")
-    do_fail = True
-
 if do_fail:
     print('Snakefile config checks FAILED.', file=sys.stderr)
     sys.exit(-1)
 
 print("Configuration PASSED!", file=sys.stderr)
-print('output directory:', OUTPUT_DIR, file=sys.stderr)
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ channels:
 dependencies:
     - snakemake-minimal>=6.4.0
     - mamba
+    - pyyaml

--- a/mash/Snakefile
+++ b/mash/Snakefile
@@ -22,8 +22,8 @@ include: '../common.snakefile'
 rule prepare_sample:
     output: directory(SAMPLE_PREP)
     conda: "../conf/env/mash2.yml"
-    log: f"{OUTPUT_DIR}/logs/mash/prepare_sample.log"
-    benchmark: f"{OUTPUT_DIR}/logs/mash/prepare_sample.benchmark"
+    log: f"{LOG_DIR}/prepare_sample.log"
+    benchmark: f"{LOG_DIR}/prepare_sample.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
@@ -33,8 +33,8 @@ rule prepare_sample:
 rule prepare_query:
     output: directory(QUERY_PREP)
     conda: "../conf/env/mash2.yml"
-    log: f"{OUTPUT_DIR}/logs/mash/prepare_query.log"
-    benchmark: f"{OUTPUT_DIR}/logs/mash/prepare_query.benchmark"
+    log: f"{LOG_DIR}/prepare_query.log"
+    benchmark: f"{LOG_DIR}/prepare_query.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
@@ -49,8 +49,8 @@ rule execute_query_command:
         query = f"{QUERY_PREP}/query.msh",
         sample = SAMPLES,
     output: directory(RESULTS_DIR)
-    log: f"{OUTPUT_DIR}/logs/mash/execute_query.log"
-    benchmark: f"{OUTPUT_DIR}/logs/mash/execute_query.benchmark"
+    log: f"{LOG_DIR}/execute_query.log"
+    benchmark: f"{LOG_DIR}/execute_query.benchmark"
     conda: "../conf/env/mash2.yml"
     shell: """
        rm -fr {output}
@@ -81,8 +81,8 @@ rule do_query:
 
 rule install_software:
     conda: "../conf/env/mash2.yml"
-    log: f"{OUTPUT_DIR}/logs/mash/install_software.log"
-    benchmark: f"{OUTPUT_DIR}/logs/mash/install_software.benchmark"
+    log: f"{LOG_DIR}/install_software.log"
+    benchmark: f"{LOG_DIR}/install_software.benchmark"
     shell: """
        mash --version 2> {log}
     """

--- a/run-many-queries
+++ b/run-many-queries
@@ -6,15 +6,25 @@ Using a bothie tool directory (e.g. ./sourmash/), run multiple queries.
 * prepare sample
 * for each query, prepare and run query
 """
+import sys
 import os
 import subprocess
 import datetime
 import shutil
 import argparse
+import yaml
+import tempfile
 
 
-def run_snakemake(target, extra_args, tool_dir):
-    cmd = f"snakemake -p -j 1 {target} {' '.join(extra_args)}"
+def run_snakemake(target, output_dir, config_d, tool_dir):
+    assert output_dir.startswith('/') # abs path
+    config_filename = os.path.join(output_dir, 'conf.yml')
+    print('writing summary config file', config_filename)
+
+    with open(config_filename, 'wt') as fp:
+        yaml.dump(config_d, fp)
+
+    cmd = f"snakemake --use-conda -p -j 1 --configfile={config_filename} {target}"
     print('running:', (cmd,))
     subprocess.check_call(cmd, shell=True, cwd=tool_dir)
 
@@ -25,7 +35,7 @@ def main():
     p.add_argument('tool', help='tool directory, e.g. sourmash')
     p.add_argument("--queries", required=True, nargs='+',
                    help="one or more query filenames")
-    p.add_argument('--output-dir', default='outputs')
+    p.add_argument('--output-dir', default=None)
     p.add_argument('--timelog', default=None)
     args = p.parse_args()
 
@@ -33,16 +43,12 @@ def main():
 
     # fix paths so that they are relative to cwd
     queries = [ os.path.abspath(q) for q in queries ]
-    args.output_dir = os.path.abspath(args.output_dir)
 
-    # clean up any pre-existing query prep
-    output_dir = args.output_dir
-    print(f'removing any query prep from output_dir {output_dir}/')
-    try:
-        query_prep = os.path.join(args.output_dir, 'prep.query')
-        shutil.rmtree(query_prep)
-    except FileNotFoundError:
-        pass
+    if args.output_dir:
+        output_dir = os.path.abspath(args.output_dir)
+    else:
+        d = tempfile.mkdtemp(prefix=f'outputs.{args.tool}.', dir='.')
+        output_dir = os.path.abspath(d)
 
     tool_dir = args.tool
     config_file = os.path.abspath(args.config_file)
@@ -51,44 +57,46 @@ def main():
     if args.timelog:
         timelog_fp = open(args.timelog, 'wt')
 
-    # note: -C / config overrides need to go at end of list
-    snakemake_args = ["--use-conda",
-                      f"--configfile {config_file}"]
+    config_file = os.path.abspath(args.config_file)
+
+    with open(config_file, 'rt') as fp:
+        config_d = yaml.safe_load(fp)
+
+    config_d['sample_prep_dir'] = os.path.join(output_dir, 'prep.sample')
+    config_d['log_dir'] = os.path.join(output_dir, 'logs')
 
     print('installing software:')
 
-    this_snakemake_args = list(snakemake_args)
-    config_args = f"-C output_dir={args.output_dir}"
-    this_snakemake_args.append(config_args)
-
-    run_snakemake('install_software', this_snakemake_args, tool_dir)
-                      
-    this_snakemake_args = list(snakemake_args)
-    config_args = f"-C output_dir={args.output_dir}"
-    this_snakemake_args.append(config_args)
+    run_snakemake('install_software', output_dir, config_d, tool_dir)
 
     print(datetime.datetime.now(), 'START SAMPLE PREP', file=timelog_fp)
-    run_snakemake('prepare_sample', this_snakemake_args, tool_dir)
+    run_snakemake('prepare_sample', output_dir, config_d, tool_dir)
     print(datetime.datetime.now(), 'END SAMPLE PREP', file=timelog_fp)
 
     results = []
 
+    num = 0
     for query in queries:
+        num += 1
         print('-----------------------------')
         print("query file:", query)
-        this_snakemake_args = list(snakemake_args)
-        config_args = f"-C query_file={query} output_dir={args.output_dir}"
-        this_snakemake_args.append(config_args)
+
+        query_prep_dir = os.path.join(output_dir, f'prep.query.{num}')
+        results_dir = os.path.join(output_dir, f'results.{num}')
+
+        config_d['query_file'] = query
+        config_d['query_prep_dir'] = query_prep_dir
+        config_d['results_dir'] = results_dir
 
         print(datetime.datetime.now(), 'START QUERY PREP', file=timelog_fp)
-        run_snakemake('prepare_query', this_snakemake_args, tool_dir)
+        run_snakemake('prepare_query', output_dir, config_d, tool_dir)
         print(datetime.datetime.now(), 'END QUERY PREP', file=timelog_fp)
 
         print(datetime.datetime.now(), 'START DO QUERY', file=timelog_fp)
-        run_snakemake('do_query', this_snakemake_args, tool_dir)
+        run_snakemake('do_query', output_dir, config_d, tool_dir)
         print(datetime.datetime.now(), 'END DO QUERY', file=timelog_fp)
 
-        result_file = os.path.join(args.output_dir, "results", "RESULT")
+        result_file = os.path.join(results_dir, "RESULT")
         assert os.path.exists(result_file)
         with open(result_file) as fp:
             result = fp.read()
@@ -99,16 +107,15 @@ def main():
                 print('SUCCESS! It was found! :)', query)
             else:
                 print('FAILURE! It was not found! ;(', query)
-            results.append((query, result))
-
-        query_prep = os.path.join(args.output_dir, 'prep.query')
-        shutil.rmtree(query_prep)
-        result_dir = os.path.join(args.output_dir, "results")
-        shutil.rmtree(result_dir)
+            results.append((query, result, results_dir))
 
     print('SUMMARY:')
-    for (query, result) in results:
-        print(query, result)
+    for (query, result, dirname,) in results:
+        dirname = os.path.relpath(dirname)
+        print(f"{query}\t{result}\t{dirname}")
+
+    print('')
+    print(f"results under {output_dir}")
 
 if __name__ == '__main__':
     main()

--- a/run-one-query
+++ b/run-one-query
@@ -69,7 +69,6 @@ def main():
     tool_dir = args.tool
     config_file = os.path.abspath(args.config_file)
 
-    # note: -C / config overrides need to go at end of list
     with open(config_file, 'rt') as fp:
         config_d = yaml.safe_load(fp)
 

--- a/run-one-query
+++ b/run-one-query
@@ -15,10 +15,19 @@ import subprocess
 import datetime
 import shutil
 import argparse
+import tempfile
+import yaml
 
 
-def run_snakemake(target, extra_args, tool_dir):
-    cmd = f"snakemake -p -j 1 {target} {' '.join(extra_args)}"
+def run_snakemake(target, output_dir, config_d, tool_dir):
+    assert output_dir.startswith('/') # abs path
+    config_filename = os.path.join(output_dir, 'conf.yml')
+    print('writing summary config file', config_filename)
+
+    with open(config_filename, 'wt') as fp:
+        yaml.dump(config_d, fp)
+
+    cmd = f"snakemake --use-conda -p -j 1 --configfile={config_filename} {target}"
     print('running:', (cmd,))
     subprocess.check_call(cmd, shell=True, cwd=tool_dir)
 
@@ -37,14 +46,16 @@ def main():
     if not os.path.isfile(args.query):
         print(f'ERROR: specified query ({args.query}) is not a file! Is the path correct?')
         sys.exit(-1)
+
     if args.output_dir:
         args.output_dir = os.path.abspath(args.output_dir)
     else:
-        # we'll set a default output path to outputs/<tool name>
-        args.output_dir = os.path.abspath('outputs/' + args.tool)
+        # we'll set a default output path to outputs.<random>
+        d = tempfile.mkdtemp(prefix=f'outputs.{args.tool}.', dir='.')
+        args.output_dir = os.path.abspath(d)
 
     output_dir = args.output_dir
-    if not args.no_clean_query:
+    if not args.no_clean_query and os.path.exists(output_dir):
         print(f'removing query prep from output_dir {output_dir}/')
         try:
             query_prep = os.path.join(args.output_dir, 'prep.query')
@@ -59,25 +70,36 @@ def main():
     config_file = os.path.abspath(args.config_file)
 
     # note: -C / config overrides need to go at end of list
-    snakemake_args = ["--use-conda",
-                      f"--configfile {config_file}",
-                      f"-C query_file={args.query} output_dir={args.output_dir}"]
+    with open(config_file, 'rt') as fp:
+        config_d = yaml.safe_load(fp)
+
+    config_d['query_file'] = args.query
+
+    config_d['sample_prep_dir'] = os.path.join(output_dir, 'prep.sample')
+    config_d['log_dir'] = os.path.join(output_dir, 'logs')
+    config_d['query_prep_dir'] = os.path.join(output_dir, 'prep.query')
+    config_d['results_dir'] = os.path.join(output_dir, 'results')
 
     print('installing software:')
 
-    run_snakemake('install_software', snakemake_args, tool_dir)
-                      
+    run_snakemake('install_software', output_dir, config_d, tool_dir)
+
     print(datetime.datetime.now(), 'START SAMPLE PREP')
-    run_snakemake('prepare_sample', snakemake_args, tool_dir)
+    run_snakemake('prepare_sample', output_dir, config_d,
+                  tool_dir)
     print(datetime.datetime.now(), 'END SAMPLE PREP')
 
     print(datetime.datetime.now(), 'START QUERY PREP')
-    run_snakemake('prepare_query', snakemake_args, tool_dir)
+    run_snakemake('prepare_query', output_dir, config_d,
+                  tool_dir)
     print(datetime.datetime.now(), 'END QUERY PREP')
 
     print(datetime.datetime.now(), 'START DO QUERY')
-    run_snakemake('do_query', snakemake_args, tool_dir)
+    run_snakemake('do_query', output_dir, config_d, tool_dir)
     print(datetime.datetime.now(), 'END DO QUERY')
+
+    print('')
+    print('results in', args.output_dir)
 
 if __name__ == '__main__':
     main()

--- a/sourmash/Snakefile
+++ b/sourmash/Snakefile
@@ -9,7 +9,7 @@ except ValueError:
     print(f"Invalid ksize {repr(ksize)}", file=sys.stderr)
     raise
 
-# this sets OUTPUT_DIR, RESULTS_DIR, SAMPLE_PREP, and QUERY_PREP
+# this sets LOG_DIR, RESULTS_DIR, SAMPLE_PREP, and QUERY_PREP
 include: '../common.snakefile'
 
 ###
@@ -19,8 +19,8 @@ include: '../common.snakefile'
 rule prepare_sample:
     output: directory(SAMPLE_PREP)
     conda: "../conf/env/sourmash4.yml"
-    log: f"{OUTPUT_DIR}/logs/sourmash/prepare_sample.log"
-    benchmark: f"{OUTPUT_DIR}/logs/sourmash/prepare_sample.benchmark"
+    log: f"{LOG_DIR}/prepare_sample.log"
+    benchmark: f"{LOG_DIR}/prepare_sample.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
@@ -32,8 +32,8 @@ rule prepare_query:
     conda: "../conf/env/sourmash4.yml"
     params:
         name = os.path.basename(QUERY)
-    log: f"{OUTPUT_DIR}/logs/sourmash/prepare_query.log"
-    benchmark: f"{OUTPUT_DIR}/logs/sourmash/prepare_query.benchmark"
+    log: f"{LOG_DIR}/prepare_query.log"
+    benchmark: f"{LOG_DIR}/prepare_query.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
@@ -47,8 +47,8 @@ rule execute_query_command:
         sample = f"{SAMPLE_PREP}/sample.sig",
     output: directory(RESULTS_DIR)
     conda: "../conf/env/sourmash4.yml"
-    log: f"{OUTPUT_DIR}/logs/sourmash/execute_query.log"
-    benchmark: f"{OUTPUT_DIR}/logs/sourmash/execute_query.benchmark"
+    log: f"{LOG_DIR}/execute_query.log"
+    benchmark: f"{LOG_DIR}/execute_query.benchmark"
     shell: """
        rm -fr {output}
        mkdir -p {output}
@@ -58,7 +58,7 @@ rule execute_query_command:
 rule do_query:
     message: "Run query and evaluate if it found it, or not."
     input: dir=RESULTS_DIR
-    benchmark: f"{OUTPUT_DIR}/logs/sourmash/do_query.benchmark"
+    benchmark: f"{LOG_DIR}/do_query.benchmark"
     run:
         with open(input.dir + '/results.csv', "rt") as fp:
             lines = fp.readlines()
@@ -75,8 +75,8 @@ rule do_query:
 
 rule install_software:
     conda: "../conf/env/sourmash4.yml"
-    log: f"{OUTPUT_DIR}/logs/sourmash/install_software.log"
-    benchmark: f"{OUTPUT_DIR}/logs/sourmash/install_software.benchmark"
+    log: f"{LOG_DIR}/install_software.log"
+    benchmark: f"{LOG_DIR}/install_software.benchmark"
     shell: """
        sourmash --version 2> {log}
     """


### PR DESCRIPTION
This PR removes the need for a single top-level output directory, which makes tool execution much more flexible.

The main effective change in the tool Snakefiles is that `OUTPUT_DIR` should no longer be used; in this PR, we replace the use of `OUTPUT_DIR` with `LOG_DIR`, which is the only place where OUTPUT_DIR was used anyway ;).

This PR also modifies the run scripts to create guaranteed-distinct output directories by default, which is nice.

In addition, `run-many-queries` now creates distinct `query.prep` and `results` output directories.


